### PR TITLE
Update jec recipe

### DIFF
--- a/Jets/ConfFile_cfg.py
+++ b/Jets/ConfFile_cfg.py
@@ -12,6 +12,11 @@ options.register('inputFormat', 'PAT',
                  VarParsing.varType.string,
                  "format of the input files (PAT or RECO)"
                  )
+options.register('updateJEC', '',
+                 VarParsing.multiplicity.list,
+                 VarParsing.varType.string,
+                 "Name of the SQLite file (with path and extension) used to update the jet collection to the latest JEC and the era of the new JEC"
+                )
 options.parseArguments()
 
 
@@ -39,6 +44,20 @@ if (options.inputFormat.lower() == "reco"):
         '/store/mc/PhaseIITDRSpring17DR/TTToSemiLepton_TuneCUETP8M1_14TeV-powheg-pythia8/AODSIM/PU200_91X_upgrade2023_realistic_v3-v1/120000/000CD008-7A58-E711-82DB-1CB72C0A3A61.root',
     ))
 
+# Get new JEC from an SQLite file rather than a GT
+if options.updateJEC:
+    from CondCore.DBCommon.CondDBSetup_cfi import *
+    process.jec = cms.ESSource("PoolDBESSource",CondDBSetup,
+                               connect = cms.string('sqlite_file:'+options.updateJEC[0]),
+                               toGet =  cms.VPSet(
+            cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                     tag = cms.string("JetCorrectorParametersCollection_"+options.updateJEC[1]+"_AK4PFPuppi"),
+                     label = cms.untracked.string("AK4PFPuppi"))
+            )
+                               )
+    process.es_prefer_jec = cms.ESPrefer("PoolDBESSource","jec")
+
+
 # run Puppi 
 process.load('CommonTools/PileupAlgos/Puppi_cff')
 process.load('CommonTools/PileupAlgos/PhotonPuppi_cff')
@@ -60,7 +79,20 @@ if (options.inputFormat.lower() == "reco"):
 process.jetfilter = cms.EDProducer(moduleName)
 process.load("PhaseTwoAnalysis.Jets."+moduleName+"_cfi")
 if (options.inputFormat.lower() == "reco"):
-    process.jetfilter.jets = "ak4PUPPIJets"    
+    if options.updateJEC:
+        process.load('PhaseTwoAnalysis.Jets.JetCorrection_cff')
+        process.jetfilter.jets = "ak4PUPPIJetsL1FastL2L3"
+    else:
+        process.jetfilter.jets = "ak4PUPPIJets"
+else:
+    if options.updateJEC:
+        from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+        updateJetCollection(process,
+                            jetSource = cms.InputTag('slimmedJetsPuppi'),
+                            postfix = 'UpdatedJECAK4PFPuppi',
+                            jetCorrections = ('AK4PFPuppi', ['L1FastJet','L2Relative','L3Absolute'], 'None')
+                            )
+        process.jetfilter.jets = "updatedPatJetsUpdatedJECAK4PFPuppi"
 
 process.out = cms.OutputModule("PoolOutputModule",
     outputCommands = cms.untracked.vstring('keep *_*_*_*',
@@ -70,8 +102,14 @@ process.out = cms.OutputModule("PoolOutputModule",
 )
   
 if (options.inputFormat.lower() == "reco"):
-    process.p = cms.Path(process.puSequence * process.jetfilter)
+    if options.updateJEC:
+        process.p = cms.Path(process.puSequence * process.ak4PFPuppiL1FastL2L3CorrectorChain * process.ak4PUPPIJetsL1FastL2L3 * process.jetfilter)
+    else:
+        process.p = cms.Path(process.puSequence * process.jetfilter)
 else:
-    process.p = cms.Path(process.jetfilter)
+    if options.updateJEC:
+        process.p = cms.Path(process.patJetCorrFactorsUpdatedJECAK4PFPuppi * process.updatedPatJetsUpdatedJECAK4PFPuppi * process.jetfilter)
+    else:
+        process.p = cms.Path(process.jetfilter)
 
 process.e = cms.EndPath(process.out)

--- a/Jets/python/JetCorrection_cff.py
+++ b/Jets/python/JetCorrection_cff.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import *
+#from JetMETCorrections.Configuration.JetCorrectors_cff import *
+
+ak4PFPuppiL1Fastjet = cms.ESProducer(
+    'L1FastjetCorrectionESProducer',
+    level       = cms.string('L1FastJet'),
+    algorithm   = cms.string('AK4PFPuppi'),
+    srcRho      = cms.InputTag('fixedGridRhoFastjetAll'),
+    )
+ak4PFPuppiL2Relative  = ak4PFL2Relative.clone( algorithm = 'AK4PFPuppi' )
+ak4PFPuppiL3Absolute  = ak4PFL3Absolute.clone( algorithm = 'AK4PFPuppi' )
+ak4PFPuppiL2L3 = cms.ESProducer(
+    'JetCorrectionESChain',
+    correctors = cms.vstring('ak4PFPuppiL2Relative','ak4PFPuppiL3Absolute')
+    )
+ak4PFPuppiL1FastL2L3 = ak4PFPuppiL2L3.clone()
+ak4PFPuppiL1FastL2L3.correctors.insert(0,'ak4PFPuppiL1Fastjet')
+
+ak4PFPuppiL1FastjetCorrector = cms.EDProducer(
+    'L1FastjetCorrectorProducer',
+    level       = cms.string('L1FastJet'),
+    algorithm   = cms.string('AK4PFPuppi'),
+    srcRho      = cms.InputTag( 'fixedGridRhoFastjetAll' )
+    )
+ak4PFPuppiL2RelativeCorrector = cms.EDProducer(
+    'LXXXCorrectorProducer',
+    level     = cms.string('L2Relative'),
+    algorithm = cms.string('AK4PFPuppi')
+    )
+ak4PFPuppiL3AbsoluteCorrector = cms.EDProducer(
+    'LXXXCorrectorProducer',
+    level     = cms.string('L3Absolute'),
+    algorithm = cms.string('AK4PFPuppi')
+    )
+ak4PFPuppiL2L3Corrector = cms.EDProducer(
+    'ChainedJetCorrectorProducer',
+    correctors = cms.VInputTag('ak4PFPuppiL2RelativeCorrector','ak4PFPuppiL3AbsoluteCorrector')
+    )
+ak4PFPuppiL1FastL2L3Corrector = ak4PFPuppiL2L3Corrector.clone()
+ak4PFPuppiL1FastL2L3Corrector.correctors.insert(0,'ak4PFPuppiL1FastjetCorrector')
+ak4PFPuppiL1FastL2L3CorrectorChain = cms.Sequence(
+    ak4PFPuppiL1FastjetCorrector * ak4PFPuppiL2RelativeCorrector * ak4PFPuppiL3AbsoluteCorrector * ak4PFPuppiL1FastL2L3Corrector
+    )
+
+ak4PUPPIJetsL1 = cms.EDProducer(
+    'CorrectedPFJetProducer',
+    src         = cms.InputTag('ak4PUPPIJets'),
+    correctors  = cms.VInputTag('ak4PUPPIL1FastjetCorrector')
+    )
+ak4PUPPIJetsL2L3 = cms.EDProducer('CorrectedPFJetProducer',
+    src         = cms.InputTag('ak4PUPPIJets'),
+    correctors  = cms.VInputTag('ak4PFPuppiL2L3Corrector')
+    )
+ak4PUPPIJetsL1FastL2L3  = ak4PUPPIJetsL2L3.clone(src = 'ak4PUPPIJets', correctors = ['ak4PFPuppiL1FastL2L3Corrector'])

--- a/Jets/python/JetCorrection_cff.py
+++ b/Jets/python/JetCorrection_cff.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import *
-#from JetMETCorrections.Configuration.JetCorrectors_cff import *
 
 ak4PFPuppiL1Fastjet = cms.ESProducer(
     'L1FastjetCorrectionESProducer',


### PR DESCRIPTION
This PR adds the ability to correct the jets to a different version of the JEC. If starting from MiniAOD the JEC will be updated, but if starting from AODSIM the JEC will be applied using a jet correction chain. The process is started by passing the configuration file a path to an SQLite file and the era of the JEC within that file (i.e. updateJEC="PhaseIISummer16_25nsV3_MC.db updateJEC=PhaseIISummer16_25nsV3_MC").

I also experimented with an alternative method for correcting the jets from AODSIM by using the JetToolbox, but this produces a std::vector<pat::Jet> rather than a std::vector<reco::PFJet>. If we switch to storing pat::Jets then we can use the JetToolbox for both corrected and uncorrected jets. This would make sense because the other objects passed to RecoJetFilter.cc are already PAT objects. Using the polymorphism of pat::Jets and reco::PFJets in unnecessarily complicated. Right now this is not implemented, but I thought I would mention it here just in case someone was interested.