### PR TITLE
add photon multicluster quantities

### DIFF
--- a/NTupler/interface/MiniEvent.h
+++ b/NTupler/interface/MiniEvent.h
@@ -45,9 +45,9 @@ struct MiniEvent_t
   Int_t j_id[maxjets], j_g[maxjets], j_mvav2[maxjets], j_deepcsv[maxjets], j_flav[maxjets], j_hadflav[maxjets], j_pid[maxjets];
   Float_t j_pt[maxjets], j_eta[maxjets], j_phi[maxjets], j_mass[maxjets];
   Float_t met_pt[maxpart], met_eta[maxpart], met_phi[maxpart];
-  Int_t lp_g[maxpart], tp_g[maxpart];
-  Float_t lp_pt[maxpart], lp_eta[maxpart], lp_phi[maxpart], lp_nrj[maxpart];
-  Float_t tp_pt[maxpart], tp_eta[maxpart], tp_phi[maxpart], tp_nrj[maxpart];
+  Int_t lp_g[maxpart], tp_g[maxpart], lp_isEB[maxpart], tp_isEB[maxpart];
+  Float_t lp_pt[maxpart], lp_eta[maxpart], lp_phi[maxpart], lp_nrj[maxpart], lp_pt_multi[maxpart], lp_eta_multi[maxpart], lp_phi_multi[maxpart], lp_nrj_multi[maxpart];
+  Float_t tp_pt[maxpart], tp_eta[maxpart], tp_phi[maxpart], tp_nrj[maxpart], tp_pt_multi[maxpart], tp_eta_multi[maxpart], tp_phi_multi[maxpart], tp_nrj_multi[maxpart];
 
 };
 

--- a/NTupler/plugins/MiniFromPat.cc
+++ b/NTupler/plugins/MiniFromPat.cc
@@ -648,11 +648,26 @@ MiniFromPat::recoAnalysis(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if (!isLoose) continue;
     if (ev_.nlp<MiniEvent_t::maxpart){
 
+       ev_.lp_isEB[ev_.nlp]   = isEB ? 1 : 0;
        ev_.lp_pt[ev_.nlp]     = photons->at(i).pt();
        ev_.lp_phi[ev_.nlp]    = photons->at(i).phi();
        ev_.lp_eta[ev_.nlp]    = photons->at(i).eta();
        ev_.lp_nrj[ev_.nlp]    = photons->at(i).energy();
        ev_.lp_g[ev_.nlp] = -1;
+       // add multicluster quantities too
+       // for endcap it's seed multi, otherwise just use supercluster
+       if (isEB) {
+         ev_.lp_pt_multi[ev_.nlp]     = photons->at(i).superCluster()->energy() / cosh(photons->at(i).superCluster()->seed()->eta());
+         ev_.lp_phi_multi[ev_.nlp]    = photons->at(i).superCluster()->phi();
+         ev_.lp_eta_multi[ev_.nlp]    = photons->at(i).superCluster()->eta();
+         ev_.lp_nrj_multi[ev_.nlp]    = photons->at(i).superCluster()->energy();
+       }
+       else {
+         ev_.lp_pt_multi[ev_.nlp]     = photons->at(i).superCluster()->seed()->energy() / cosh(photons->at(i).superCluster()->seed()->eta());
+         ev_.lp_phi_multi[ev_.nlp]    = photons->at(i).superCluster()->seed()->phi();
+         ev_.lp_eta_multi[ev_.nlp]    = photons->at(i).superCluster()->seed()->eta();
+         ev_.lp_nrj_multi[ev_.nlp]    = photons->at(i).superCluster()->seed()->energy();
+       }
        for (int ig = 0; ig < ev_.ngp; ig++) {
          if (reco::deltaR(ev_.gp_eta[ig],ev_.gp_phi[ig],ev_.lp_eta[ev_.nlp],ev_.lp_phi[ev_.nlp]) > 0.4) continue;
          ev_.lp_g[ev_.nlp]    = ig;
@@ -663,11 +678,26 @@ MiniFromPat::recoAnalysis(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if (!isTight) continue;
     if (ev_.ntp>=MiniEvent_t::maxpart) break;
 
+    ev_.tp_isEB[ev_.ntp]   = isEB ? 1 : 0;
     ev_.tp_pt[ev_.ntp]     = photons->at(i).pt();
     ev_.tp_phi[ev_.ntp]    = photons->at(i).phi();
     ev_.tp_eta[ev_.ntp]    = photons->at(i).eta();
     ev_.tp_nrj[ev_.ntp]    = photons->at(i).energy();
     ev_.tp_g[ev_.ntp] = -1;
+    // add multicluster quantities too
+    // for endcap it's seed multi, otherwise just use supercluster
+    if (isEB) {
+      ev_.tp_pt_multi[ev_.ntp]     = photons->at(i).superCluster()->energy() / cosh(photons->at(i).superCluster()->seed()->eta());
+      ev_.tp_phi_multi[ev_.ntp]    = photons->at(i).superCluster()->phi();
+      ev_.tp_eta_multi[ev_.ntp]    = photons->at(i).superCluster()->eta();
+      ev_.tp_nrj_multi[ev_.ntp]    = photons->at(i).superCluster()->energy();
+    }
+    else {
+      ev_.tp_pt_multi[ev_.ntp]     = photons->at(i).superCluster()->seed()->energy() / cosh(photons->at(i).superCluster()->seed()->eta());
+      ev_.tp_phi_multi[ev_.ntp]    = photons->at(i).superCluster()->seed()->phi();
+      ev_.tp_eta_multi[ev_.ntp]    = photons->at(i).superCluster()->seed()->eta();
+      ev_.tp_nrj_multi[ev_.ntp]    = photons->at(i).superCluster()->seed()->energy();
+    }
     for (int ig = 0; ig < ev_.ngp; ig++) {
       if (reco::deltaR(ev_.gp_eta[ig],ev_.gp_phi[ig],ev_.tp_eta[ev_.ntp],ev_.tp_phi[ev_.ntp]) > 0.4) continue;
       ev_.tp_g[ev_.ntp]    = ig;

--- a/NTupler/src/MiniEvent.cc
+++ b/NTupler/src/MiniEvent.cc
@@ -101,18 +101,28 @@ void createMiniEventTree(TTree *t_event_, TTree *t_genParts_, TTree *t_vertices_
   t_puppiMET_->Branch("Phi",            ev.met_phi,     "Phi[PuppiMissingET_size]/F");
   t_puppiMET_->Branch("Eta",            ev.met_eta,     "Eta[PuppiMissingET_size]/F");
 
-  t_loosePhotons_->Branch("PhotonLoose_size", &ev.nlp,  "PhotonLoose_size/I");
-  t_loosePhotons_->Branch("Particle",     ev.lp_g,        "Particle[PhotonLoose_size]/I");
-  t_loosePhotons_->Branch("PT",           ev.lp_pt,       "PT[PhotonLoose_size]/F");
-  t_loosePhotons_->Branch("Eta",          ev.lp_eta,      "Eta[PhotonLoose_size]/F");
-  t_loosePhotons_->Branch("Phi",          ev.lp_phi,      "Phi[PhotonLoose_size]/F");
-  t_loosePhotons_->Branch("E",            ev.lp_nrj,      "E[PhotonLoose_size]/F");
+  t_loosePhotons_->Branch("PhotonLoose_size", &ev.nlp,     "PhotonLoose_size/I");
+  t_loosePhotons_->Branch("Particle",     ev.lp_g,         "Particle[PhotonLoose_size]/I");
+  t_loosePhotons_->Branch("IsEB",         ev.lp_isEB,      "IsEB[PhotonLoose_size]/I");
+  t_loosePhotons_->Branch("PT",           ev.lp_pt,        "PT[PhotonLoose_size]/F");
+  t_loosePhotons_->Branch("Eta",          ev.lp_eta,       "Eta[PhotonLoose_size]/F");
+  t_loosePhotons_->Branch("Phi",          ev.lp_phi,       "Phi[PhotonLoose_size]/F");
+  t_loosePhotons_->Branch("E",            ev.lp_nrj,       "E[PhotonLoose_size]/F");
+  t_loosePhotons_->Branch("PT_multi",     ev.lp_pt_multi,  "PT_multi[PhotonLoose_size]/F");
+  t_loosePhotons_->Branch("Eta_multi",    ev.lp_eta_multi, "Eta_multi[PhotonLoose_size]/F");
+  t_loosePhotons_->Branch("Phi_multi",    ev.lp_phi_multi, "Phi_multi[PhotonLoose_size]/F");
+  t_loosePhotons_->Branch("E_multi",      ev.lp_nrj_multi, "E_multi[PhotonLoose_size]/F");
 
-  t_tightPhotons_->Branch("PhotonTight_size", &ev.ntp,  "PhotonTight_size/I");
-  t_tightPhotons_->Branch("Particle",     ev.tp_g,        "Particle[PhotonTight_size]/I");
-  t_tightPhotons_->Branch("PT",           ev.tp_pt,       "PT[PhotonTight_size]/F");
-  t_tightPhotons_->Branch("Eta",          ev.tp_eta,      "Eta[PhotonTight_size]/F");
-  t_tightPhotons_->Branch("Phi",          ev.tp_phi,      "Phi[PhotonTight_size]/F");
-  t_tightPhotons_->Branch("E",            ev.tp_nrj,      "E[PhotonTight_size]/F");
+  t_tightPhotons_->Branch("PhotonTight_size", &ev.ntp,     "PhotonTight_size/I");
+  t_tightPhotons_->Branch("Particle",     ev.tp_g,         "Particle[PhotonTight_size]/I");
+  t_tightPhotons_->Branch("IsEB",         ev.tp_isEB,      "IsEB[PhotonTight_size]/I");
+  t_tightPhotons_->Branch("PT",           ev.tp_pt,        "PT[PhotonTight_size]/F");
+  t_tightPhotons_->Branch("Eta",          ev.tp_eta,       "Eta[PhotonTight_size]/F");
+  t_tightPhotons_->Branch("Phi",          ev.tp_phi,       "Phi[PhotonTight_size]/F");
+  t_tightPhotons_->Branch("E",            ev.tp_nrj,       "E[PhotonTight_size]/F");
+  t_tightPhotons_->Branch("PT_multi",     ev.tp_pt_multi,  "PT_multi[PhotonTight_size]/F");
+  t_tightPhotons_->Branch("Eta_multi",    ev.tp_eta_multi, "Eta_multi[PhotonTight_size]/F");
+  t_tightPhotons_->Branch("Phi_multi",    ev.tp_phi_multi, "Phi_multi[PhotonTight_size]/F");
+  t_tightPhotons_->Branch("E_multi",      ev.tp_nrj_multi, "E_multi[PhotonTight_size]/F");
 }
 


### PR DESCRIPTION
Add branches for the seed multicluster quantities for endcap photons (gives best energy resolution and robustness against PU). These can be used in conjunction with the photon energy correction histograms here [1], although automatic application is not yet implemented in the code. 

[1] /afs/cern.ch/work/e/escott/public/HGCStudies/PhotonECorrections